### PR TITLE
docs: Update composer installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,23 +15,11 @@ PHP 5.5 and later
 
 ### Composer
 
-To install the bindings via [Composer](http://getcomposer.org/), add the following to `composer.json`:
+To install with [Composer](http://getcomposer.org/), run:
 
-```json
-{
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/ory/hydra-client-php.git"
-    }
-  ],
-  "require": {
-    "ory/hydra-client-php": "*@dev"
-  }
-}
+```bash
+$ composer require ory/hydra-client:*
 ```
-
-Then run `composer install`
 
 ### Manual Installation
 


### PR DESCRIPTION
This PR updates the composer installation instructions. 

This encourages developers to use the package from [https://packagist.org/packages/ory/hydra-client](https://packagist.org/packages/ory/hydra-client) instead of loading the package from the Github repository.